### PR TITLE
spec language in c comments get highlighted now as well

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,9 +62,12 @@
         ]
       },
       {
-        "path": "syntaxes/comment_injection_java.tmLanguage.json",
+        "path": "syntaxes/comment_injection_java_c.tmLanguage.json",
         "scopeName": "java-comment-spec.injection",
-        "injectTo": ["source.java"]
+        "injectTo": [
+          "source.java",
+          "source.c"
+        ]
       }
     ],
     "commands": [

--- a/syntaxes/comment_injection_java_c.tmLanguage.json
+++ b/syntaxes/comment_injection_java_c.tmLanguage.json
@@ -1,6 +1,6 @@
 {
   "scopeName": "java-comment-spec.injection",
-  "injectionSelector": "L:source.java",
+  "injectionSelector": "L:source.java,L:source.c",
   
   "patterns": [
       {


### PR DESCRIPTION
added a bit in comment_injection_java.tmLanguage.json so that it also injected the comment in structure in C. hence the renaming of the file to syntaxes/comment_injection_java_c.tmLanguage.json (could've also removed the _java_c part, but i guess not all languages use this syntax for comments

Also added a line in the package.json file to make it work in c as well